### PR TITLE
Replace abstractions project reference with package reference

### DIFF
--- a/src/Coderynx.MediatorKit/Coderynx.MediatorKit.csproj
+++ b/src/Coderynx.MediatorKit/Coderynx.MediatorKit.csproj
@@ -23,11 +23,8 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Coderynx.MediatorKit.Abstractions" Version="1.6.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.6"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\Coderynx.MediatorKit.Abstractions\Coderynx.MediatorKit.Abstractions.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
This pull request updates the `Coderynx.MediatorKit` project to use a package reference instead of a project reference for the `Coderynx.MediatorKit.Abstractions` dependency. This change simplifies dependency management by relying on a specific version of the package.

Dependency management updates:

* [`src/Coderynx.MediatorKit/Coderynx.MediatorKit.csproj`](diffhunk://#diff-186247eae6e0d4ce944a1d643769cbdb56fcbe40a6b0058e40b59c8b6dac3633R26-L32): Added a `PackageReference` for `Coderynx.MediatorKit.Abstractions` (version 1.6.0) and removed the `ProjectReference` to the local project.