### PR TITLE
Ensure idempotent dependency registration for MediatorKit

### DIFF
--- a/src/Coderynx.MediatorKit/DependencyInjection.cs
+++ b/src/Coderynx.MediatorKit/DependencyInjection.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Coderynx.MediatorKit.Abstractions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Coderynx.MediatorKit;
 
@@ -17,7 +18,8 @@ public class MediatorKitBuilder
         where TPipelineBehavior : class, IRequestPipelineBehavior<TRequest, TResponse>
         where TRequest : IRequest<TResponse>
     {
-        Services.AddScoped<IRequestPipelineBehavior<TRequest, TResponse>, TPipelineBehavior>();
+        Services.TryAddEnumerable(
+            ServiceDescriptor.Scoped<IRequestPipelineBehavior<TRequest, TResponse>, TPipelineBehavior>());
         return this;
     }
 
@@ -37,7 +39,7 @@ public class MediatorKitBuilder
                 "Behavior type must implement IRequestPipelineBehavior<,> (Parameter 'behaviorType')");
         }
 
-        Services.AddScoped(typeof(IRequestPipelineBehavior<,>), behaviorType);
+        Services.TryAddEnumerable(ServiceDescriptor.Scoped(typeof(IRequestPipelineBehavior<,>), behaviorType));
         return this;
     }
 
@@ -57,7 +59,7 @@ public class MediatorKitBuilder
 
         foreach (var handler in handlers)
         {
-            Services.AddScoped(handler.Interface, handler.Type);
+            Services.TryAddScoped(handler.Interface, handler.Type);
         }
     }
 
@@ -65,7 +67,8 @@ public class MediatorKitBuilder
         where TPipelineBehavior : class, INotificationPipelineBehavior<TNotification>
         where TNotification : INotification
     {
-        Services.AddScoped<INotificationPipelineBehavior<TNotification>, TPipelineBehavior>();
+        Services.TryAddEnumerable(
+            ServiceDescriptor.Scoped<INotificationPipelineBehavior<TNotification>, TPipelineBehavior>());
         return this;
     }
 
@@ -85,7 +88,7 @@ public class MediatorKitBuilder
                 "Behavior type must implement INotificationPipelineBehavior<> (Parameter 'behaviorType')");
         }
 
-        Services.AddScoped(typeof(INotificationPipelineBehavior<>), behaviorType);
+        Services.TryAddEnumerable(ServiceDescriptor.Scoped(typeof(INotificationPipelineBehavior<>), behaviorType));
         return this;
     }
 
@@ -101,7 +104,7 @@ public class MediatorKitBuilder
 
         foreach (var handler in handlers)
         {
-            Services.AddScoped(handler.Interface, handler.Type);
+            Services.TryAddEnumerable(ServiceDescriptor.Scoped(handler.Interface, handler.Type));
         }
     }
 
@@ -116,7 +119,7 @@ public class MediatorKitBuilder
 
         foreach (var handler in handlers)
         {
-            Services.AddScoped(handler.Interface, handler.Type);
+            Services.TryAddEnumerable(ServiceDescriptor.Scoped(handler.Interface, handler.Type));
         }
     }
 }
@@ -128,7 +131,7 @@ public static class DependencyInjection
         var builder = new MediatorKitBuilder(services);
         configure?.Invoke(builder);
 
-        services.AddScoped<ISender, Sender>();
-        services.AddScoped<IPublisher, Publisher>();
+        services.TryAddScoped<ISender, Sender>();
+        services.TryAddScoped<IPublisher, Publisher>();
     }
 }

--- a/src/Coderynx.MediatorKit/version.json
+++ b/src/Coderynx.MediatorKit/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],

--- a/tests/Coderynx.MediatorKit.Tests/NotificationTests/DependencyInjectionTests.cs
+++ b/tests/Coderynx.MediatorKit.Tests/NotificationTests/DependencyInjectionTests.cs
@@ -27,6 +27,21 @@ public sealed class DependencyInjectionTests
     }
 
     [Fact]
+    public void AddMediatorKit_ShouldNotOverwritePublisher_WhenAlreadyRegistered()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddScoped<IPublisher, CustomPublisher>();
+
+        // Act
+        services.AddMediatorKit();
+
+        // Assert
+        var serviceDescriptor = services.First(s => s.ServiceType == typeof(IPublisher));
+        Assert.Equal(typeof(CustomPublisher), serviceDescriptor.ImplementationType);
+    }
+
+    [Fact]
     public void AddPipelineBehavior_Generic_ShouldRegisterBehavior()
     {
         // Arrange
@@ -136,6 +151,27 @@ public sealed class DependencyInjectionTests
     }
 
     [Fact]
+    public void AddMediatorKit_ShouldNotDuplicateNotificationHandlers_WhenCalledMultipleTimes()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddMediatorKit(mediator =>
+            mediator.AddNotificationHandlersFromAssembly(typeof(TestNotificationHandler).Assembly));
+        services.AddMediatorKit(mediator =>
+            mediator.AddNotificationHandlersFromAssembly(typeof(TestNotificationHandler).Assembly));
+
+        // Assert
+        var handlers = services
+            .Where(s => s.ServiceType == typeof(INotificationHandler<TestNotification>)
+                        && s.ImplementationType == typeof(TestNotificationHandler))
+            .ToList();
+
+        Assert.Single(handlers);
+    }
+
+    [Fact]
     public async Task SendAsync_ShouldReturnResult()
     {
         // Arrange
@@ -166,5 +202,13 @@ public sealed class DependencyInjectionTests
 
         // Act
         await sender.PublishAsync(new TestNotification());
+    }
+}
+
+internal sealed class CustomPublisher : IPublisher
+{
+    public Task PublishAsync(INotification notification, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/tests/Coderynx.MediatorKit.Tests/RequestTests/DependencyInjectionTests.cs
+++ b/tests/Coderynx.MediatorKit.Tests/RequestTests/DependencyInjectionTests.cs
@@ -26,6 +26,21 @@ public sealed class DependencyInjectionTests
     }
 
     [Fact]
+    public void AddMediatorKit_ShouldNotOverwriteSender_WhenAlreadyRegistered()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddScoped<ISender, CustomSender>();
+
+        // Act
+        services.AddMediatorKit();
+
+        // Assert
+        var serviceDescriptor = services.First(s => s.ServiceType == typeof(ISender));
+        Assert.Equal(typeof(CustomSender), serviceDescriptor.ImplementationType);
+    }
+
+    [Fact]
     public void AddMediatorKit_ShouldExecuteConfigureAction_WhenProvided()
     {
         // Arrange
@@ -148,6 +163,27 @@ public sealed class DependencyInjectionTests
     }
 
     [Fact]
+    public void AddMediatorKit_ShouldNotDuplicateRequestHandlers_WhenCalledMultipleTimes()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddMediatorKit(mediator =>
+            mediator.AddRequestHandlersFromAssembly(typeof(TestRequestHandler).Assembly));
+        services.AddMediatorKit(mediator =>
+            mediator.AddRequestHandlersFromAssembly(typeof(TestRequestHandler).Assembly));
+
+        // Assert
+        var handlers = services
+            .Where(s => s.ServiceType == typeof(IRequestHandler<TestRequest, int>)
+                        && s.ImplementationType == typeof(TestRequestHandler))
+            .ToList();
+
+        Assert.Single(handlers);
+    }
+
+    [Fact]
     public async Task SendAsync_ShouldReturnResult()
     {
         // Arrange
@@ -184,5 +220,14 @@ public sealed class DependencyInjectionTests
 
         // Assert
         Assert.Equal(1, result);
+    }
+}
+
+internal sealed class CustomSender : ISender
+{
+    public Task<TResponse> SendAsync<TResponse>(IRequest<TResponse> request,
+        CancellationToken cancellationToken = new())
+    {
+        throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
This pull request updates the dependency injection logic in `MediatorKit` to prevent duplicate service registrations and avoid overwriting existing registrations for core interfaces like `ISender` and `IPublisher`. It replaces `AddScoped` with `TryAddScoped` and `TryAddEnumerable` to ensure that services are only registered if they haven't already been added, improving compatibility and reliability when integrating with other libraries or when configuring services multiple times. The tests have been expanded to verify these behaviors.

Dependency injection improvements:

* Replaced `AddScoped` with `TryAddScoped` for core services (`ISender`, `IPublisher`) in `DependencyInjection.cs` to prevent overwriting existing registrations.
* Updated registration of pipeline behaviors and handlers to use `TryAddEnumerable` or `TryAddScoped`, ensuring duplicate registrations are avoided when adding handlers or behaviors multiple times. [[1]](diffhunk://#diff-551c192b9bb71f89f27cc212e9d699f2bd0ed35a999c40056b520650e6b8af8eL20-R22) [[2]](diffhunk://#diff-551c192b9bb71f89f27cc212e9d699f2bd0ed35a999c40056b520650e6b8af8eL40-R42) [[3]](diffhunk://#diff-551c192b9bb71f89f27cc212e9d699f2bd0ed35a999c40056b520650e6b8af8eL60-R71) [[4]](diffhunk://#diff-551c192b9bb71f89f27cc212e9d699f2bd0ed35a999c40056b520650e6b8af8eL88-R91) [[5]](diffhunk://#diff-551c192b9bb71f89f27cc212e9d699f2bd0ed35a999c40056b520650e6b8af8eL104-R107) [[6]](diffhunk://#diff-551c192b9bb71f89f27cc212e9d699f2bd0ed35a999c40056b520650e6b8af8eL119-R122)

Testing enhancements:

* Added unit tests to verify that `AddMediatorKit` does not overwrite existing `ISender` or `IPublisher` registrations. [[1]](diffhunk://#diff-3da5c50a40712edadd6cef71e42e3176accdb155a503f66ea880c7f9df10d58dR28-R42) [[2]](diffhunk://#diff-e0dbdef7583a279442cfbf257189de5a3ff3ea0aea35d068482c5f4ebfcacf4eR29-R43)
* Added tests to ensure that request and notification handlers are not registered multiple times when `AddMediatorKit` is called repeatedly. [[1]](diffhunk://#diff-3da5c50a40712edadd6cef71e42e3176accdb155a503f66ea880c7f9df10d58dR165-R185) [[2]](diffhunk://#diff-e0dbdef7583a279442cfbf257189de5a3ff3ea0aea35d068482c5f4ebfcacf4eR153-R173)
* Introduced custom sender and publisher classes in test files to facilitate these new tests. [[1]](diffhunk://#diff-3da5c50a40712edadd6cef71e42e3176accdb155a503f66ea880c7f9df10d58dR225-R233) [[2]](diffhunk://#diff-e0dbdef7583a279442cfbf257189de5a3ff3ea0aea35d068482c5f4ebfcacf4eR207-R214)

Version update:

* Bumped package version from `1.8.0` to `1.9.0` in `version.json`.